### PR TITLE
Create Spring Boot Maven starter project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# core
+# Spring Boot Maven Project
+
+این پروژه با **Spring Boot** و **Maven** ساخته شده است.
+
+## اجرا
+
+```bash
+mvn spring-boot:run
+```
+
+سپس این آدرس را باز کنید:
+
+- `http://localhost:8080/`
+
+## تست
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.6</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>demo</name>
+    <description>Demo Spring Boot project with Maven</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/demo/HelloController.java
+++ b/src/main/java/com/example/demo/HelloController.java
@@ -1,0 +1,13 @@
+package com.example.demo;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/")
+    public String hello() {
+        return "سلام! پروژه Spring Boot با Maven آماده است.";
+    }
+}

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal Spring Boot + Maven starter so the repository contains a runnable application scaffold and basic smoke test.

### Description

- Add `pom.xml` with Spring Boot parent (3.5.6), `spring-boot-starter-web`, `spring-boot-starter-test`, and the `spring-boot-maven-plugin`.
- Add application entry point `src/main/java/com/example/demo/DemoApplication.java` that boots Spring Boot.
- Add a simple REST controller `src/main/java/com/example/demo/HelloController.java` exposing `/` and returning a Persian greeting.
- Add a basic context-load test `src/test/java/com/example/demo/DemoApplicationTests.java` and update `README.md` with run/test instructions.

### Testing

- Ran `mvn test`, which failed in this environment because Maven Central returned `403 Forbidden` when attempting to download the Spring Boot parent POM, so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a97b9b2c4832491b40978f8db31f3)