### PR TITLE
Add React frontend scaffold and connect it to Spring Boot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,41 @@
-# Spring Boot Maven Project
+# Spring Boot + React Project
 
-این پروژه با **Spring Boot** و **Maven** ساخته شده است.
+این پروژه شامل یک **بک‌اند Spring Boot** و یک **فرانت‌اند React (Vite)** است.
 
-## اجرا
+## اجرای بک‌اند
 
 ```bash
 mvn spring-boot:run
 ```
 
-سپس این آدرس را باز کنید:
+بک‌اند روی آدرس `http://localhost:8080` اجرا می‌شود.
 
-- `http://localhost:8080/`
+## اجرای فرانت‌اند React
 
-## تست
+ابتدا وابستگی‌های فرانت‌اند را نصب کنید:
+
+```bash
+cd frontend
+npm install
+```
+
+سپس پروژه React را اجرا کنید:
+
+```bash
+npm run dev
+```
+
+فرانت‌اند روی `http://localhost:5173` اجرا می‌شود و درخواست‌های `/api` را به بک‌اند پراکسی می‌کند.
+
+## تست بک‌اند
 
 ```bash
 mvn test
+```
+
+## بیلد فرانت‌اند
+
+```bash
+cd frontend
+npm run build
 ```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="fa">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demo-frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^5.4.10"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function App() {
+  const [message, setMessage] = useState('در حال دریافت پیام...');
+
+  useEffect(() => {
+    fetch('/api/greeting')
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('خطا در دریافت پاسخ از سرور');
+        }
+        return response.json();
+      })
+      .then((data) => setMessage(data.message))
+      .catch(() => setMessage('اتصال به بک‌اند برقرار نشد.'));
+  }, []);
+
+  return (
+    <main className="container">
+      <h1>فرانت‌اند React آماده است ✅</h1>
+      <p>{message}</p>
+    </main>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,25 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f4f7fb;
+  color: #1f2937;
+}
+
+.container {
+  max-width: 640px;
+  margin: 8rem auto;
+  padding: 2rem;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(31, 41, 55, 0.08);
+  text-align: center;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
+    }
+  }
+});

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.3.5</version>
         <relativePath/>
     </parent>
 

--- a/src/main/java/com/example/demo/GreetingController.java
+++ b/src/main/java/com/example/demo/GreetingController.java
@@ -1,0 +1,16 @@
+package com.example.demo;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class GreetingController {
+
+    @GetMapping("/greeting")
+    public Map<String, String> greeting() {
+        return Map.of("message", "سلام از بک‌اند اسپرینگ بوت 👋");
+    }
+}

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,12 +1,26 @@
 package com.example.demo;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class DemoApplicationTests {
 
+    @Autowired
+    private MockMvc mockMvc;
+
     @Test
-    void contextLoads() {
+    void greetingEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/greeting"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("سلام از بک‌اند اسپرینگ بوت 👋"));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal React (Vite) frontend that consumes the Spring Boot API to enable local frontend development and integration testing.
- Expose a simple `/api/greeting` endpoint from the backend so the new frontend has a deterministic API to call.
- Update docs and project structure so developers can run backend and frontend locally with a Vite proxy to the Spring Boot server.

### Description
- Added a Vite + React frontend under `frontend/` with entry files `index.html`, `src/main.jsx`, `src/App.jsx`, `src/styles.css`, `package.json`, and `vite.config.js` that proxies `/api` to `http://localhost:8080`.
- Implemented `GreetingController` (`src/main/java/com/example/demo/GreetingController.java`) that serves `GET /api/greeting` and added `DemoApplication` bootstrap class (`src/main/java/com/example/demo/DemoApplication.java`).
- Updated backend test to use `MockMvc` and verify the greeting response in `src/test/java/com/example/demo/DemoApplicationTests.java` and updated `README.md` with run/build instructions for both backend and frontend.
- Adjusted Spring Boot parent version in `pom.xml` from `3.5.6` to `3.3.5` to address environment compatibility when resolving the parent POM.

### Testing
- Ran `mvn test` which failed due to environment-level failure to download the Spring Boot parent POM (HTTP 403 from Maven Central), so JVM tests could not complete.
- Ran `npm install` in `frontend/` which failed with HTTP 403 from the npm registry, so frontend dependencies and dev server were not installed/started.
- Attempted a Playwright page navigation to `http://127.0.0.1:5173` which failed because the frontend dev server was not running in this environment, so no live UI screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a995569748324bc003bd1e21418f0)