### PR TITLE
Integrate React frontend build into Maven lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,26 @@
-# Spring Boot + React Project
+# Spring Boot + React (Single Maven Build)
 
-این پروژه شامل یک **بک‌اند Spring Boot** و یک **فرانت‌اند React (Vite)** است.
+در این ساختار، فرانت‌اند React و بک‌اند Spring Boot داخل یک پروژه Maven نگه داشته شده‌اند و خروجی فرانت‌اند در زمان بیلد Maven ساخته و داخل `static/` بک‌اند قرار می‌گیرد.
 
-## اجرای بک‌اند
+## اجرا با Maven
 
 ```bash
 mvn spring-boot:run
 ```
 
-بک‌اند روی آدرس `http://localhost:8080` اجرا می‌شود.
+با اجرای دستور بالا:
+- Maven وابستگی‌های فرانت‌اند را نصب می‌کند.
+- فرانت‌اند را بیلد می‌کند.
+- خروجی را به منابع استاتیک Spring Boot کپی می‌کند.
+- برنامه را روی `http://localhost:8080` اجرا می‌کند.
 
-## اجرای فرانت‌اند React
+API همچنان از مسیر `http://localhost:8080/api/greeting` در دسترس است.
 
-ابتدا وابستگی‌های فرانت‌اند را نصب کنید:
-
-```bash
-cd frontend
-npm install
-```
-
-سپس پروژه React را اجرا کنید:
+## بیلد نهایی
 
 ```bash
-npm run dev
+mvn clean package
 ```
-
-فرانت‌اند روی `http://localhost:5173` اجرا می‌شود و درخواست‌های `/api` را به بک‌اند پراکسی می‌کند.
 
 ## تست بک‌اند
 
@@ -33,9 +28,12 @@ npm run dev
 mvn test
 ```
 
-## بیلد فرانت‌اند
+## توسعه فرانت‌اند (اختیاری)
+
+اگر خواستید فقط روی UI سریع‌تر کار کنید، می‌توانید همچنان به شکل جداگانه Vite را اجرا کنید:
 
 ```bash
 cd frontend
-npm run build
+npm install
+npm run dev
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
 
     <properties>
         <java.version>21</java.version>
+        <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
+        <node.version>v20.17.0</node.version>
+        <npm.version>10.8.2</npm.version>
     </properties>
 
     <dependencies>
@@ -35,6 +38,70 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin.version}</version>
+                <configuration>
+                    <workingDirectory>frontend</workingDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-node-and-npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <nodeVersion>${node.version}</nodeVersion>
+                            <npmVersion>${npm.version}</npmVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-ci</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-build</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-frontend-to-static</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/static</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/frontend/dist</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/com/example/demo/SpaForwardController.java
+++ b/src/main/java/com/example/demo/SpaForwardController.java
@@ -1,0 +1,13 @@
+package com.example.demo;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SpaForwardController {
+
+    @GetMapping(value = {"/", "/{path:[^\\.]*}", "/**/{path:[^\\.]*}"})
+    public String forward() {
+        return "forward:/index.html";
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single Maven-driven workflow so the React frontend is built and served together with the Spring Boot backend.
- Ensure the frontend static assets are packaged into the backend so the app can be run with a single `mvn` command.

### Description
- Added `frontend-maven-plugin` configuration to `pom.xml` to install Node/NPM and run `npm ci` and `npm run build` during the Maven lifecycle with Node/NPM versions defined by properties.
- Added a `maven-resources-plugin` execution in `pom.xml` to copy the frontend `dist` output into `${project.build.outputDirectory}/static` so Spring Boot serves the built UI.
- Added `src/main/java/com/example/demo/SpaForwardController.java` to forward SPA routes (non-file paths) to `index.html` so client-side routing works when served by Spring Boot.
- Updated `README.md` to document the single-command Maven workflow (`mvn spring-boot:run` and `mvn clean package`) and the optional frontend dev flow (`cd frontend && npm install && npm run dev`).

### Testing
- Ran `mvn test` in the environment to validate the build lifecycle, but the run failed due to inability to resolve the Spring Boot parent POM from Maven Central (HTTP 403), so tests could not complete successfully.
- No unit/test failures in the code itself were observed prior to the repository dependency resolution error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab128b1448324b3d3a5be74215938)